### PR TITLE
fix: variable balances fixed due compiling errors

### DIFF
--- a/contracts/GuardianToken.sol
+++ b/contracts/GuardianToken.sol
@@ -90,7 +90,7 @@ contract GuardianToken {
      */
     function mint(address account, uint256 amount) external isOwner {
         totalSupply += amount;
-        balances[account] += amount;
+        balanceOf[account] += amount;
         emit Transfer(address(0), account, amount);
     }
 


### PR DESCRIPTION
The mint function in this contract used the mapping "balances" while the ERC20 implementation itself uses "balanceOf" as a balances mapping.